### PR TITLE
WIP: Debian / compat with msmtpd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 PREFIX ?= /usr
+BIN_SUFFIX ?=
+
 # Where the script binary should go
 BINPATH = $(DESTDIR)$(PREFIX)/bin
 SBINPATH = $(DESTDIR)$(PREFIX)/sbin
 MANPATH = $(DESTDIR)$(PREFIX)/share/man/man1
 SHAREDIR = $(DESTDIR)$(PREFIX)/share/smailq
 CONFFILE = $(SHAREDIR)/smailq.conf.sample
-
 ######################################################################
 
 all: manpage
@@ -13,8 +14,8 @@ all: manpage
 install: all
 	mkdir -p $(BINPATH) $(SBINPATH) $(MANPATH) $(SHAREDIR)
 	install -m 0755 smailq $(BINPATH)/smailq
-	install -m 0755 mailq $(BINPATH)/mailq
-	install -m 0755 sendmail $(SBINPATH)/sendmail
+	install -m 0755 mailq $(BINPATH)/mailq$(BIN_SUFFIX)
+	install -m 0755 sendmail $(SBINPATH)/sendmail$(BIN_SUFFIX)
 	install -m 0644 smailq.conf $(CONFFILE)
 	install -m 0644 smailq.1 $(MANPATH)/smailq.1
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,6 @@ Standards-Version: 2.0.0-rc
 
 Package: smailq
 Replaces: mail-transport-agent
-Conflicts: mail-transport-agent
 Depends: python3
 Section: mail
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,7 @@ install: build
 	dh_prep
 	dh_installdirs
 
-	$(MAKE) install DESTDIR=$(CURDIR)/debian/smailq
+	$(MAKE) install DESTDIR=$(CURDIR)/debian/smailq BIN_SUFFIX=.smailq
 
 binary-indep: install
 	dh_testdir

--- a/debian/smailq.postinst
+++ b/debian/smailq.postinst
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+if [ -e /usr/share/debconf/confmodule ]; then
+    . /usr/share/debconf/confmodule
+fi
+
+#DEBHELPER#
+
+case "$1" in
+    configure)
+	update-alternatives --install /usr/sbin/sendmail sendmail /usr/sbin/sendmail.smailq 5 \
+			    --slave /usr/lib/sendmail lib-sendmail /usr/sbin/sendmail.smailq;
+	update-alternatives --set sendmail /usr/sbin/sendmail.smailq || true
+	update-alternatives --set lib-sendmail /usr/sbin/sendmail.smailq || true
+	;;
+esac


### PR DESCRIPTION
Abilty to suffix the sbin/ binary and use update-alternative so that smailq can be installed alongside msmtpd (msmtp-mta on Debian)

Related: https://salsa.debian.org/kolter/msmtp/-/merge_requests/15